### PR TITLE
Dmem: Add more configuration

### DIFF
--- a/tcl/board/ti_am625evm-self.cfg
+++ b/tcl/board/ti_am625evm-self.cfg
@@ -8,6 +8,9 @@
 # We are using dmem, which uses dapdirect_swd
 adapter driver dmem
 
+dmem base_address 0x700000000
+dmem ap_address_offset 0x100
+dmem max_aps 10
 # default JTAG configuration has only SRST and no TRST
 reset_config srst_only srst_push_pull
 


### PR DESCRIPTION
Add configurability to allow us to support various SoCs

Ideally these would end up in a userspace linux driver similar to 
https://github.com/Mellanox/rshim-user-space/blob/master/src/rshim.c